### PR TITLE
Fix start command

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "dev:offline": "DEV_MODE=\"offline\" npm run dev",
-    "start": "astro dev",
+    "start": "node ./dist/server/entry.mjs",
     "build": "astro check && astro build",
     "preview": "astro preview",
     "astro": "astro",


### PR DESCRIPTION
Your site is currently running the development server in production as `astro dev` is the default  `start` script, and I'm guessing that's the default on render. In production, you'll want to start the server from the build output with `node ./dist/server/entry.mjs`.